### PR TITLE
Extract ResourceEditor component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,3 +60,9 @@ label {
 {
     display: unset;
 }
+
+.block-hax {
+    margin: 3px;
+    padding: 10px;
+    display: block;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,162 @@
-import { Link, Text, Resource } from "./core/resources";
+import { Text, Resource } from "./core/resources";
 import { Tree, makeTree, TreeNode, NodeID, serializeTree, deserializeTree } from "./core/tree";
+
+import ResourceEditor from "./ResourceEditor";
+
 import React, { Component } from "react";
 import { debounce } from "lodash";
 import saveAs from "file-saver";
+
 import "./App.css";
 import "react-tree-graph/dist/style.css";
 
+// TODO: unhax it
 const ReactTreeGraph:any = require("react-tree-graph"); // missing external types, haxing it'!
+
+
+export default class App extends Component<{
+}, {
+    chosenNode: NodeID,
+    ourTree: Tree<Resource>
+}>
+{
+    // TODO: what is the correct empty props type? o.0
+    constructor(props: object)
+    {
+        super(props);
+
+        const ourTree = makeTree({address: "korzen", is_done: false}) ;
+
+        this.state= {
+            chosenNode: ourTree.root.id,
+            ourTree,
+        };
+    }
+
+    attachNewNodeToSelected = (r: Resource) =>
+    {
+        this.setState({
+            ourTree: this.state.ourTree.add(this.state.chosenNode, r),
+        });
+    }
+
+    removeSelectedNode = () => 
+    {
+        // TODO: select parent of the deleted node
+        this.setState({
+            ourTree: this.state.ourTree.removeNode(this.state.chosenNode),
+        });
+
+        // TODO: don't leak implementation details - use a method to get root iD!!!
+        this.selectNode(Number.MIN_SAFE_INTEGER);
+    }
+
+    selectNode = (node_id: NodeID) =>
+    {
+        this.setState({
+            chosenNode: node_id,
+        });
+    }
+
+    replaceSelectedNodeContents = (r: Resource) =>
+    {
+        // TODO: get rid of private access
+        // TODO: make the interface look immutable
+        this.state.ourTree._selectNodeById(this.state.chosenNode).data = r;
+
+        this.setState({
+            ourTree: this.state.ourTree,
+        });
+    }
+
+    readFromFile(event: React.FormEvent<HTMLInputElement>)
+    {
+        console.assert(!!event.currentTarget.files, "handler is attached to <input type='file'> ")
+        if (!event.currentTarget.files) return;
+
+        const file = event.currentTarget.files[0];
+
+        const reader = new FileReader();
+
+        // TODO: how to type this event properly?
+        reader.onload = (onload_event: any) =>
+        {
+            const raw_file_contents = onload_event.target.result;
+
+            const tree = deserializeTree<Resource>(raw_file_contents);
+
+            this.setState({
+                ourTree: tree,
+                chosenNode: tree.root.id
+            });
+        };
+        // TODO: Handle this
+        //reader.onerror = function (evt) {
+        //};
+
+        reader.readAsText(file);
+    }
+
+    outputToFile()
+    {
+        const dumpedTree = serializeTree(this.state.ourTree);
+        // TODO: unhax the type
+        (saveAs as any)(new Blob([dumpedTree], {type: "text/plain;charset=utf-8"}), "tree.json");
+    }
+
+    render()
+    {
+        return (
+            <div className="App">
+                {
+                    // TODO: extract this to seperate component
+                }
+                <ReactTreeGraph
+                    data={displayTree(this.state.ourTree)}
+                    gProps={{
+                        onClick: (_: any, node_id: NodeID) => { this.selectNode(node_id) }
+                    }}
+                    width={window.innerWidth * (3/4)}
+                    height={window.innerHeight * (3/4)}
+                    keyProp="id"
+                />
+
+                <ResourceEditor 
+                    key={this.state.chosenNode}
+                    resource={this.state.ourTree.nodeData(this.state.chosenNode)}
+                    isDeletable={this.state.ourTree.isRoot(this.state.chosenNode)}
+                    onDelete={this.removeSelectedNode}
+                    onAdd={this.attachNewNodeToSelected}
+                    onEditonCommit={this.replaceSelectedNodeContents}
+                />
+
+                {
+                    // TODO: extract this to seperate component
+                }
+                <div className="block-hax">
+                    <form encType="multipart/form-data" noValidate>
+                        <label className="file-uploader-label">Siorbaj z pliku:</label>
+                        <input type="file" onChange = { e => this.readFromFile(e) }/>
+                    </form>
+                    <button onClick = { e => this.outputToFile() }>Pluj do pliku</button>
+                </div>
+            </div>
+        );
+    }
+
+    debouncedHandleResize = debounce(() => this.forceUpdate(), 200);
+
+    componentDidMount()
+    {
+        window.addEventListener("resize", this.debouncedHandleResize);
+    }
+
+    componentWillUnmount()
+    {
+        window.removeEventListener("resize", this.debouncedHandleResize);
+    }
+
+}
 
 
 interface ReactTreeGraphNode {
@@ -48,145 +198,4 @@ function displayTree(t: Tree<Resource>): ReactTreeGraphNode
     }
 
     return _displayTree(t.root);
-}
-
-export default class App extends Component<{}, { chosenNode: NodeID, value: string, ourTree: Tree<Resource>}>
-{
-    constructor(props: any)
-    {
-        super(props);
-
-        const ourTree = makeTree({address: "korzen", is_done: false}) ;
-
-        this.state= {
-            value: "Name", // TODO: can we get rid of this?
-            chosenNode: ourTree.root.id,
-            ourTree,
-        };
-        this.handleChange = this.handleChange.bind(this);
-        this.debouncedHandleResize = this.debouncedHandleResize.bind(this);
-    }
-
-    // TODO: ffs
-    handleChange(event: any) 
-    {
-        this.setState({value: event.target.value});
-        event.preventDefault();
-    }
-
-    readFromFile(event: any)
-    {
-        const file = event.target.files[0];
-        const reader = new FileReader();
-
-        reader.onload = (onload_event: any) =>
-        {
-            const raw_file_contents = onload_event.target.result;
-
-            const tree = deserializeTree<Resource>(raw_file_contents);
-
-            this.setState({
-                ourTree: tree,
-                chosenNode: tree.root.id
-            });
-        };
-
-        // TODO: Handle this
-        //reader.onerror = function (evt) {
-        //};
-
-        reader.readAsText(file);
-    }
-
-    outputToFile()
-    {
-        const dumpedTree = serializeTree(this.state.ourTree);
-        (saveAs as any)(new Blob([dumpedTree], {type: "text/plain;charset=utf-8"}), "tree.json");
-    }
-
-    addCustom(event: any, node_id: NodeID, address: string)
-    {
-        // TODO: dehardcode the Link type
-        this.setState({
-            ourTree: this.state.ourTree.add(node_id, {address, is_done: false}),
-        });
-    }
-
-    remove(event: any)
-    {
-        this.state.ourTree.removeNode(this.state.chosenNode);
-
-        // TODO: select parent of the deleted node
-        this.setState({
-            ourTree: this.state.ourTree,
-            chosenNode: Number.MIN_SAFE_INTEGER,
-        });
-    }
-
-    selectNode(event: any, node_id: NodeID)
-    {
-        this.setState({
-            chosenNode: node_id,
-        });
-    }
-
-    editNode(event: any, value: string)
-    {
-        // TODO: get rid of private access
-        // TODO: dehardcode the Link type
-        (this.state.ourTree._selectNodeById(this.state.chosenNode).data as Link).address = value;
-
-        this.setState({
-            ourTree: this.state.ourTree,
-        });
-
-    }
-
-    debouncedHandleResize = debounce(() => this.forceUpdate(), 200);
-
-    componentDidMount()
-    {
-        window.addEventListener("resize", this.debouncedHandleResize);
-    }
-
-    componentWillUnmount()
-    {
-        window.removeEventListener("resize", this.debouncedHandleResize);
-    }
-
-    render()
-    {
-        return (
-            <div className="App">
-                <ReactTreeGraph
-                    data={displayTree(this.state.ourTree)}
-                    gProps={{
-                        onClick: this.selectNode.bind(this)
-                    }}
-                    width={window.innerWidth * (3/4)}
-                    height={window.innerHeight * (3/4)}
-                    keyProp="id"
-                />
-
-                {
-                    // TODO: extract NodeEditor component
-                    // TODO: add a proper editor that respects resource type
-                }
-                <label>Selected node: {this.state.chosenNode}</label>
-                <button onClick = { e => this.remove(e) } disabled={this.state.ourTree.isRootId(this.state.chosenNode)}>Usuń</button>
-                <input type="text" name="node" value={this.state.value} onChange={this.handleChange}/>
-                {
-                    // TODO: add a possiblity to select type to add (then it's just editor)
-                    // right now it's fixed to link
-                }
-                <button onClick = { e => this.addCustom(e, this.state.chosenNode, this.state.value) }>Dodaj</button>
-                <button onClick = { e => this.editNode(e, this.state.value) }>Edytuj</button>
-                <button onClick = { e => this.outputToFile() }>Pluj do pliku</button>
-                <form encType="multipart/form-data" noValidate>
-                    <label className="file-uploader-label">Siorbaj z pliku:</label>
-                    <input type="file" onChange = { e => this.readFromFile(e) }/>
-                </form>
-            </div>
-        );
-    }
 }

--- a/src/ResourceEditor.tsx
+++ b/src/ResourceEditor.tsx
@@ -1,0 +1,69 @@
+import { Link, Resource } from "./core/resources";
+import React, { Component } from "react";
+
+import "./ResourceEditor.css";
+
+
+export default class ResourceEditor extends Component<{
+    resource: Resource,
+    isDeletable: boolean,
+    onDelete: () => void,
+    onAdd: (resource: Resource) => void,
+    onEditonCommit: (resource: Resource) => void
+}, {
+    resource: Resource,
+}>
+{
+    // TODO: what is the correct props type? o.0
+    // TODO: can I type the props once?
+    constructor(props: any)
+    {
+        super(props);
+
+        this.state = {
+            resource: this.props.resource,
+        };
+    }
+
+    handleChange = (event: React.FormEvent<HTMLInputElement>) =>
+    {
+        this.setState({
+            resource: {
+                ...this.state.resource,
+                address: event.currentTarget.value,
+            }
+        })
+    }    
+
+    render()
+    {
+        return(
+            <div>
+                {
+                    // TODO: remove the hax and organize css classes
+                    // TODO: clean App.css from NodeEditor-specific stuff
+                }
+                {
+                    // TODO: editor should reflect on resource type
+                    // TODO: add a possiblity to select type to add (then it's just editor)
+                    // right now it's fixed to link
+                }
+                <label className="file-uploader-label">address</label>
+                <input 
+                    type="text"
+                    defaultValue={(this.props.resource as Link).address}
+                    onChange={ this.handleChange }
+                />
+                <div className="block-hax"></div>
+                <button 
+                    disabled={this.props.isDeletable}
+                    onClick={ _ => this.props.onDelete()}
+                >
+                    Usuń
+                </button>
+                <button onClick={ _ => this.props.onAdd(this.state.resource) }> Dodaj</button>
+                <button onClick={ _ => this.props.onEditonCommit(this.state.resource) }>Edytuj</button>
+            </div>
+        );
+    }
+}

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -38,6 +38,7 @@ export class Tree<T>
         }
         finally
         {
+            console.assert(!isNaN(newId), "generated ID is not NaN")
             targetNode._append(new TreeNode(newId, data, []));
         }
 
@@ -63,7 +64,7 @@ export class Tree<T>
 
     removeNode(which: NodeID): Tree<T>
     {
-        if(this.isRootId(which))
+        if(this.isRoot(which))
         {
             throw new Error("Cannot delete root");
         }
@@ -95,6 +96,11 @@ export class Tree<T>
         return this.root.equals(other.root);
     }
 
+    nodeData(id: NodeID): T
+    {
+        return this._selectNodeById(id).data;
+    }
+
     // TODO: optional? - undo the ignore
     _selectNodeById(target_id: NodeID): TreeNode<T>
     {
@@ -102,7 +108,7 @@ export class Tree<T>
         return this.root.flatten().find(node => node.id === target_id);
     }
 
-    isRootId(id: NodeID): boolean
+    isRoot(id: NodeID): boolean
     {
         return this.dependencies.idProvider.isRootId(id);
     }


### PR DESCRIPTION
This commit doesn't change anything functionally

The main component was getting slightly out of hand. This also allowed
me to establish cleaner boundaries between domain objects - the
ResourceEditor is unaware of any Tree (and so would be TreeDisplay after
extraction) and the main component couldn't care less about what exactly
resources are [aside from creating the initial tree]

Had some issues with synchronizing changes on the address filed of the
form, yet the key approach (https://stackoverflow.com/a/53313430/9134286)
yielded good results. Conceptually you can think of it as both:
- an array of ResourceEditors that happens to haven only one element
- the ResourceEditor being spun up for every node that has a potential
to be edited by the user (which right now is the selected node) and
discarded when not needed

I'd like to than my former employer for making processors that allow
this a bit wasteful, yet marvelously elegant design