### PR TITLE
Add effective resource awareness

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.4",
     "file-saver": "^2.0.2",
+    "formik": "^2.1.4",
     "lodash": "^4.17.15",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Text, Resource } from "./core/resources";
 import { Tree, makeTree, TreeNode, NodeID, serializeTree, deserializeTree } from "./core/tree";
 
 import ResourceEditor from "./ResourceEditor";
+import ResourceAdder from "./ResourceAdder";
 
 import React, { Component } from "react";
 import { debounce } from "lodash";
@@ -25,7 +26,7 @@ export default class App extends Component<{
     {
         super(props);
 
-        const ourTree = makeTree({address: "korzen", is_done: false}) ;
+        const ourTree = makeTree({content: "korzen", is_done: false});
 
         this.state= {
             chosenNode: ourTree.root.id,
@@ -121,13 +122,19 @@ export default class App extends Component<{
                     keyProp="id"
                 />
 
+                {
+                    // TODO: Extract ResourceRemover
+                }
                 <ResourceEditor 
                     key={this.state.chosenNode}
                     resource={this.state.ourTree.nodeData(this.state.chosenNode)}
                     isDeletable={!this.state.ourTree.isRoot(this.state.chosenNode)}
                     onDelete={this.removeSelectedNode}
-                    onAdd={this.attachNewNodeToSelected}
                     onEditonCommit={this.replaceSelectedNodeContents}
+                />
+
+                <ResourceAdder
+                    onAdd={this.attachNewNodeToSelected}
                 />
 
                 {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,13 +42,13 @@ export default class App extends Component<{
 
     removeSelectedNode = () => 
     {
+        // TODO: any way of writing this DRY without breaking atomicity (both updates must happen in 1 cycle)?
         // TODO: select parent of the deleted node
+        // TODO: don't leak implementation details - use a method to get root iD!!!
         this.setState({
             ourTree: this.state.ourTree.removeNode(this.state.chosenNode),
+            chosenNode: Number.MIN_SAFE_INTEGER
         });
-
-        // TODO: don't leak implementation details - use a method to get root iD!!!
-        this.selectNode(Number.MIN_SAFE_INTEGER);
     }
 
     selectNode = (node_id: NodeID) =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,7 +124,7 @@ export default class App extends Component<{
                 <ResourceEditor 
                     key={this.state.chosenNode}
                     resource={this.state.ourTree.nodeData(this.state.chosenNode)}
-                    isDeletable={this.state.ourTree.isRoot(this.state.chosenNode)}
+                    isDeletable={!this.state.ourTree.isRoot(this.state.chosenNode)}
                     onDelete={this.removeSelectedNode}
                     onAdd={this.attachNewNodeToSelected}
                     onEditonCommit={this.replaceSelectedNodeContents}

--- a/src/ResourceAdder.tsx
+++ b/src/ResourceAdder.tsx
@@ -1,0 +1,51 @@
+import { Resource } from "./core/resources";
+
+import React, { FunctionComponent } from "react";
+import { Formik, Form, Field } from "formik";
+
+// TODO: do csses right
+import "./ResourceAdder.css";
+
+
+// TODO: is is possible to reflect this from Resource union given proper typenames on interfaces?
+type TypeString = "Link" | "Text";
+
+const ResourceAdder: React.FunctionComponent<{
+    onAdd: (resource: Resource) => void,
+}> = (props) =>
+    <Formik
+        initialValues={{
+            typestring: "Link"
+        }}
+        onSubmit={(values, _) => 
+        {
+            const { typestring } = values;
+
+            // TODO: get rid of this hax
+            props.onAdd(default_for_typestring(typestring as any)); 
+        }}
+    >
+        {
+            // for whatever reason the "translate" attribute is needed
+        }
+        <Form translate="yes"> 
+            <Field name="typestring" component="select">
+                <option value="Link">Link</option>
+                <option value="Text">Text</option>
+            </Field>
+
+            <button type="submit"> Dodaj </button>
+        </Form>
+    </Formik>
+
+export default ResourceAdder;
+
+
+// TODO: make this a field on a resource
+function default_for_typestring(t: TypeString): Resource
+{
+    return {
+        "Link": { address: "", is_done: false },
+        "Text": { content: "", is_done: false },
+    }[t];
+}

--- a/src/ResourceEditor.tsx
+++ b/src/ResourceEditor.tsx
@@ -56,7 +56,7 @@ export default class ResourceEditor extends Component<{
                 />
                 <div className="block-hax"></div>
                 <button 
-                    disabled={this.props.isDeletable}
+                    disabled={!this.props.isDeletable}
                     onClick={ _ => this.props.onDelete()}
                 >
                     Usuń

--- a/src/ResourceEditor.tsx
+++ b/src/ResourceEditor.tsx
@@ -1,73 +1,87 @@
-import { Link, Resource } from "./core/resources";
+import { Resource } from "./core/resources";
 
 import React, { FunctionComponent } from "react";
 import { Formik, Form, Field } from "formik";
 
+// TODO: remove the block-hax and organize css classes
+// TODO: clean App.css from NodeEditor-specific stuff
 import "./ResourceEditor.css";
-
-
-type SubmissionAction = "ADD" | "EDIT";
-
-// TODO: unhax this after https://github.com/jaredpalmer/formik/pull/2437 is completed
-let hax: SubmissionAction = "ADD";
 
 
 const ResourceEditor: React.FunctionComponent<{
     resource: Resource,
     isDeletable: boolean,
     onDelete: () => void,
-    onAdd: (resource: Resource) => void,
     onEditonCommit: (resource: Resource) => void,
 }> = (props) =>
     <Formik
         initialValues={
-            // TODO: editor should reflect on resource type
-            {
-                address: (props.resource as Link).address
-            }
+            initial_fields_for_resource(props.resource)
         }
         onSubmit={(values, actions) =>
         {
-            const submission_action = hax;
             const resource = {
                 ...values,
                 is_done: false,
             };
 
-            if (submission_action === "ADD")
-            {
-                props.onAdd(resource);
-            }
-            else
-            {
-                console.assert(submission_action === "EDIT", "submission_action is edition commit")
-                props.onEditonCommit(resource);
-            }
+            props.onEditonCommit(resource as any);
         }}
     >
         {
             // for whatever reason the "translate" attribute is needed
         }
         <Form translate="yes"> 
-            {
-                // TODO: remove the block-hax and organize css classes
-                // TODO: clean App.css from NodeEditor-specific stuff
-            }
-            {
-                // TODO: editor should reflect on resource type
-            }
-            <label className="file-uploader-label">address</label>
-            <Field name="address" />
+            { resource_to_fields(props.resource) }
 
-            {
-                // TODO: add a possiblity to select type to add (then it's just editor)
-                // right now it's fixed to link
-            }
             <div className="block-hax"></div>
-            <button type="submit" disabled={!props.isDeletable} onClick={ _ => props.onDelete()} > Usuń </button>
-            <button type="submit" onClick={ () => { hax = "ADD" } } > Dodaj </button>
-            <button type="submit" onClick={ () => { hax = "EDIT" } } > Edytuj </button>
+            <button type="button" disabled={!props.isDeletable} onClick={ _ => props.onDelete()} > Usuń </button>
+            <button type="submit"> Edytuj </button>
         </Form>
     </Formik>
 
 export default ResourceEditor;
+
+
+// TODO: use reflection instead of hardcode
+// TODO: is the filedset a good idea here?
+function resource_to_fields(r: Resource): Array<JSX.Element>
+{
+    return [
+        {
+            property: "address",
+            jsx: <fieldset>
+                <label className="file-uploader-label">address</label>
+                <Field name="address" />
+            </fieldset>
+        },
+        {
+            property: "content",
+            jsx: <fieldset>
+                <label className="file-uploader-label">content</label>
+                <Field name="content" />
+            </fieldset>
+        },
+    ]
+        .filter(x => x.property in r)
+        .map(x => x.jsx)
+    ;
+}
+
+// TODO: use reflection instead of hardcode
+// TODO: return type will actually be a Resource 0.o
+function initial_fields_for_resource(r: Resource): object
+{
+    return [
+        "address",
+        "content",
+    ]
+        .filter(x => x in r)
+        .reduce((obj, prop) =>
+        {
+            // TODO: do something about the types
+            (obj as any)[prop] = (r as any)[prop];
+            return obj;
+        }, {})
+    ;
+}

--- a/src/ResourceEditor.tsx
+++ b/src/ResourceEditor.tsx
@@ -1,69 +1,73 @@
 import { Link, Resource } from "./core/resources";
-import React, { Component } from "react";
+
+import React, { FunctionComponent } from "react";
+import { Formik, Form, Field } from "formik";
 
 import "./ResourceEditor.css";
 
 
-export default class ResourceEditor extends Component<{
+type SubmissionAction = "ADD" | "EDIT";
+
+// TODO: unhax this after https://github.com/jaredpalmer/formik/pull/2437 is completed
+let hax: SubmissionAction = "ADD";
+
+
+const ResourceEditor: React.FunctionComponent<{
     resource: Resource,
     isDeletable: boolean,
     onDelete: () => void,
     onAdd: (resource: Resource) => void,
-    onEditonCommit: (resource: Resource) => void
-}, {
-    resource: Resource,
-}>
-{
-    // TODO: what is the correct props type? o.0
-    // TODO: can I type the props once?
-    constructor(props: any)
-    {
-        super(props);
-
-        this.state = {
-            resource: this.props.resource,
-        };
-    }
-
-    handleChange = (event: React.FormEvent<HTMLInputElement>) =>
-    {
-        this.setState({
-            resource: {
-                ...this.state.resource,
-                address: event.currentTarget.value,
+    onEditonCommit: (resource: Resource) => void,
+}> = (props) =>
+    <Formik
+        initialValues={
+            // TODO: editor should reflect on resource type
+            {
+                address: (props.resource as Link).address
             }
-        })
-    }    
+        }
+        onSubmit={(values, actions) =>
+        {
+            const submission_action = hax;
+            const resource = {
+                ...values,
+                is_done: false,
+            };
 
-    render()
-    {
-        return(
-            <div>
-                {
-                    // TODO: remove the hax and organize css classes
-                    // TODO: clean App.css from NodeEditor-specific stuff
-                }
-                {
-                    // TODO: editor should reflect on resource type
-                    // TODO: add a possiblity to select type to add (then it's just editor)
-                    // right now it's fixed to link
-                }
-                <label className="file-uploader-label">address</label>
-                <input 
-                    type="text"
-                    defaultValue={(this.props.resource as Link).address}
-                    onChange={ this.handleChange }
-                />
-                <div className="block-hax"></div>
-                <button 
-                    disabled={!this.props.isDeletable}
-                    onClick={ _ => this.props.onDelete()}
-                >
-                    Usuń
-                </button>
-                <button onClick={ _ => this.props.onAdd(this.state.resource) }> Dodaj</button>
-                <button onClick={ _ => this.props.onEditonCommit(this.state.resource) }>Edytuj</button>
-            </div>
-        );
-    }
-}
+            if (submission_action === "ADD")
+            {
+                props.onAdd(resource);
+            }
+            else
+            {
+                console.assert(submission_action === "EDIT", "submission_action is edition commit")
+                props.onEditonCommit(resource);
+            }
+        }}
+    >
+        {
+            // for whatever reason the "translate" attribute is needed
+        }
+        <Form translate="yes"> 
+            {
+                // TODO: remove the block-hax and organize css classes
+                // TODO: clean App.css from NodeEditor-specific stuff
+            }
+            {
+                // TODO: editor should reflect on resource type
+            }
+            <label className="file-uploader-label">address</label>
+            <Field name="address" />
+
+            {
+                // TODO: add a possiblity to select type to add (then it's just editor)
+                // right now it's fixed to link
+            }
+            <div className="block-hax"></div>
+            <button type="submit" disabled={!props.isDeletable} onClick={ _ => props.onDelete()} > Usuń </button>
+            <button type="submit" onClick={ () => { hax = "ADD" } } > Dodaj </button>
+            <button type="submit" onClick={ () => { hax = "EDIT" } } > Edytuj </button>
+        </Form>
+    </Formik>
+
+export default ResourceEditor;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,9 +3235,9 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
     cssom "0.3.x"
 
 csstype@^2.2.0:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
-  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
+  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -3337,6 +3337,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-gateway@^4.2.0:
   version "4.2.0"
@@ -4369,6 +4374,20 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+formik@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.4.tgz#8deef07ec845ea98f75e03da4aad7aab4ac46570"
+  integrity sha512-oKz8S+yQBzuQVSEoxkqqJrKQS5XJASWGVn6mrs+oTWrBoHgByVwwI1qHiVc9GKDpZBU9vAxXYAKz2BvujlwunA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    scheduler "^0.18.0"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -4717,6 +4736,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -6148,6 +6174,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash-es@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -8182,6 +8213,16 @@ react-error-overlay@^6.0.3:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.6.tgz#ac4d9dc4c1b5c536c2c312bf66aa2b09bfa384e2"
   integrity sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==
 
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
@@ -8733,6 +8774,14 @@ saxes@^3.1.9:
   integrity sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==
   dependencies:
     xmlchars "^2.1.1"
+
+scheduler@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
+  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.19.0:
   version "0.19.0"
@@ -9529,6 +9578,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9606,7 +9660,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.6.tgz#389a24396d425a0d3162e96d2b4638900fdc289a"
   integrity sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==


### PR DESCRIPTION
Before the change from the user point of view there was virtually no
different between Link and Text, right now that changes. We'll
capitalize on it soon!

Previously we were doing some haxes around Formik multi-path submission
yet it occurred to me that this whole mess could be avoided if we simply
splitted the functionality. A so I did!

Furthermore I've added a TODO for extracting the delete functionality to
another tiny component. It's turtles all the way down

As for the liberal use of "as any" - I don't want to be stuck in TS
peculiarities at this very moment