### PR TITLE
Add effective resource awareness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Text, Resource } from "./core/resources";
 import { Tree, makeTree, TreeNode, NodeID, serializeTree, deserializeTree } from "./core/tree";
 
 import ResourceEditor from "./ResourceEditor";
+import ResourceAdder from "./ResourceAdder";
 
 import React, { Component } from "react";
 import { debounce } from "lodash";
@@ -25,7 +26,7 @@ export default class App extends Component<{
     {
         super(props);
 
-        const ourTree = makeTree({address: "korzen", is_done: false}) ;
+        const ourTree = makeTree({content: "korzen", is_done: false});
 
         this.state= {
             chosenNode: ourTree.root.id,
@@ -121,13 +122,19 @@ export default class App extends Component<{
                     keyProp="id"
                 />
 
+                {
+                    // TODO: Extract ResourceRemover
+                }
                 <ResourceEditor 
                     key={this.state.chosenNode}
                     resource={this.state.ourTree.nodeData(this.state.chosenNode)}
                     isDeletable={!this.state.ourTree.isRoot(this.state.chosenNode)}
                     onDelete={this.removeSelectedNode}
-                    onAdd={this.attachNewNodeToSelected}
                     onEditonCommit={this.replaceSelectedNodeContents}
+                />
+
+                <ResourceAdder
+                    onAdd={this.attachNewNodeToSelected}
                 />
 
                 {

--- a/src/ResourceAdder.tsx
+++ b/src/ResourceAdder.tsx
@@ -1,0 +1,51 @@
+import { Resource } from "./core/resources";
+
+import React, { FunctionComponent } from "react";
+import { Formik, Form, Field } from "formik";
+
+// TODO: do csses right
+import "./ResourceAdder.css";
+
+
+// TODO: is is possible to reflect this from Resource union given proper typenames on interfaces?
+type TypeString = "Link" | "Text";
+
+const ResourceAdder: React.FunctionComponent<{
+    onAdd: (resource: Resource) => void,
+}> = (props) =>
+    <Formik
+        initialValues={{
+            typestring: "Link"
+        }}
+        onSubmit={(values, _) => 
+        {
+            const { typestring } = values;
+
+            // TODO: get rid of this hax
+            props.onAdd(default_for_typestring(typestring as any)); 
+        }}
+    >
+        {
+            // for whatever reason the "translate" attribute is needed
+        }
+        <Form translate="yes"> 
+            <Field name="typestring" component="select">
+                <option value="Link">Link</option>
+                <option value="Text">Text</option>
+            </Field>
+
+            <button type="submit"> Dodaj </button>
+        </Form>
+    </Formik>
+
+export default ResourceAdder;
+
+
+// TODO: make this a field on a resource
+function default_for_typestring(t: TypeString): Resource
+{
+    return {
+        "Link": { address: "", is_done: false },
+        "Text": { content: "", is_done: false },
+    }[t];
+}

--- a/src/ResourceEditor.tsx
+++ b/src/ResourceEditor.tsx
@@ -1,73 +1,87 @@
-import { Link, Resource } from "./core/resources";
+import { Resource } from "./core/resources";
 
 import React, { FunctionComponent } from "react";
 import { Formik, Form, Field } from "formik";
 
+// TODO: remove the block-hax and organize css classes
+// TODO: clean App.css from NodeEditor-specific stuff
 import "./ResourceEditor.css";
-
-
-type SubmissionAction = "ADD" | "EDIT";
-
-// TODO: unhax this after https://github.com/jaredpalmer/formik/pull/2437 is completed
-let hax: SubmissionAction = "ADD";
 
 
 const ResourceEditor: React.FunctionComponent<{
     resource: Resource,
     isDeletable: boolean,
     onDelete: () => void,
-    onAdd: (resource: Resource) => void,
     onEditonCommit: (resource: Resource) => void,
 }> = (props) =>
     <Formik
         initialValues={
-            // TODO: editor should reflect on resource type
-            {
-                address: (props.resource as Link).address
-            }
+            initial_fields_for_resource(props.resource)
         }
         onSubmit={(values, actions) =>
         {
-            const submission_action = hax;
             const resource = {
                 ...values,
                 is_done: false,
             };
 
-            if (submission_action === "ADD")
-            {
-                props.onAdd(resource);
-            }
-            else
-            {
-                console.assert(submission_action === "EDIT", "submission_action is edition commit")
-                props.onEditonCommit(resource);
-            }
+            props.onEditonCommit(resource as any);
         }}
     >
         {
             // for whatever reason the "translate" attribute is needed
         }
         <Form translate="yes"> 
-            {
-                // TODO: remove the block-hax and organize css classes
-                // TODO: clean App.css from NodeEditor-specific stuff
-            }
-            {
-                // TODO: editor should reflect on resource type
-            }
-            <label className="file-uploader-label">address</label>
-            <Field name="address" />
+            { resource_to_fields(props.resource) }
 
-            {
-                // TODO: add a possiblity to select type to add (then it's just editor)
-                // right now it's fixed to link
-            }
             <div className="block-hax"></div>
-            <button type="submit" disabled={!props.isDeletable} onClick={ _ => props.onDelete()} > Usuń </button>
-            <button type="submit" onClick={ () => { hax = "ADD" } } > Dodaj </button>
-            <button type="submit" onClick={ () => { hax = "EDIT" } } > Edytuj </button>
+            <button type="button" disabled={!props.isDeletable} onClick={ _ => props.onDelete()} > Usuń </button>
+            <button type="submit"> Edytuj </button>
         </Form>
     </Formik>
 
 export default ResourceEditor;
+
+
+// TODO: use reflection instead of hardcode
+// TODO: is the filedset a good idea here?
+function resource_to_fields(r: Resource): Array<JSX.Element>
+{
+    return [
+        {
+            property: "address",
+            jsx: <fieldset>
+                <label className="file-uploader-label">address</label>
+                <Field name="address" />
+            </fieldset>
+        },
+        {
+            property: "content",
+            jsx: <fieldset>
+                <label className="file-uploader-label">content</label>
+                <Field name="content" />
+            </fieldset>
+        },
+    ]
+        .filter(x => x.property in r)
+        .map(x => x.jsx)
+    ;
+}
+
+// TODO: use reflection instead of hardcode
+// TODO: return type will actually be a Resource 0.o
+function initial_fields_for_resource(r: Resource): object
+{
+    return [
+        "address",
+        "content",
+    ]
+        .filter(x => x in r)
+        .reduce((obj, prop) =>
+        {
+            // TODO: do something about the types
+            (obj as any)[prop] = (r as any)[prop];
+            return obj;
+        }, {})
+    ;
+}


### PR DESCRIPTION
Before the change from the user point of view there was virtually no
different between Link and Text, right now that changes. We'll
capitalize on it soon!

Previously we were doing some haxes around Formik multi-path submission
yet it occurred to me that this whole mess could be avoided if we simply
splitted the functionality. A so I did!

Furthermore I've added a TODO for extracting the delete functionality to
another tiny component. It's turtles all the way down

As for the liberal use of "as any" - I don't want to be stuck in TS
peculiarities at this very moment