### PR TITLE
Get rid of reenumerating in deserializeTree

### DIFF
--- a/src/core/tree.test.ts
+++ b/src/core/tree.test.ts
@@ -207,3 +207,12 @@ test("deleting root throws an error", () =>
 
     expect(() => {tree.removeNode(rootId)}).toThrow("Cannot delete root");
 });
+
+test("deserializing tree always assigns ROOT_ID to root node", () => 
+{
+    const tree = treeRoot.clone();
+    const deserializedTree = deserializeTree(serializeTree(tree));
+
+    expect(deserializedTree.root.id).toBe(deserializedTree.dependencies.idProvider.ROOT_ID);
+});
+

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -174,8 +174,6 @@ export function deserializeTree<T>(data: string): Tree<T>
         targetNode._append(new TreeNode(node.id, node.data, []));
     });
 
-    tree.root._reenumerate(tree.dependencies.idProvider.generate);
-
     return tree;
 }
 

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -174,6 +174,8 @@ export function deserializeTree<T>(data: string): Tree<T>
         targetNode._append(new TreeNode(node.id, node.data, []));
     });
 
+    tree.root.children.forEach((child) => child._reenumerate(tree.dependencies.idProvider.generate));
+
     return tree;
 }
 


### PR DESCRIPTION
Problem was caused by makeTree initializing TreeIdProvider and then the same TreeIdProvider was used to reenumerate root and the rest of the tree.
It means that counter in TreeIdProvider was already shifted by one. Root node was given LOWER_ID_BOUND+1 id and therefore was not properly recognized as root node by isRootId and isDeletable methods :).

Can we get rid of _reenumerate, I see no point in having this method.