### PR TITLE
Hide selected filename prompt

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,3 +87,7 @@ label {
   min-height: 25vh;
   background-color: #444;
 }
+
+.import-input {
+    color: transparent;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -258,7 +258,7 @@ export default class App extends Component<{
                         <div className="block-hax">
                             <form encType="multipart/form-data" noValidate>
                                 <label className="file-uploader-label">Import:</label>
-                                <input type="file" onChange = { e => this.readFromFile(e) }/>
+                                <input type="file" className="import-input" onChange = { e => this.readFromFile(e) }/>
                             </form>
                             <button onClick = { e => this.outputToFile() }>Export</button>
                         </div>


### PR DESCRIPTION
Usually the <input type="file" ...> provides a prompt about which file
was selected / the information that no file was selected at all. In our
case it's only confusing and not needed, since the file is acted upon
instantly after selection.